### PR TITLE
[macOS 27] Bring back menu icons

### DIFF
--- a/LunarBarMac/Modules/Sources/AppKitExtensions/NSMenuItem+Extension.swift
+++ b/LunarBarMac/Modules/Sources/AppKitExtensions/NSMenuItem+Extension.swift
@@ -14,4 +14,24 @@ public extension NSMenuItem {
   func setOn(_ on: Bool) {
     state = on ? .on : .off
   }
+
+  func ensureImageVisibility() {
+    guard #available(macOS 27.0, *) else {
+      return
+    }
+
+  #if canImport(FoundationModels, _version: 2)
+    preferredImageVisibility = .visible
+  #else
+    let selector = sel_getUid("setPreferredImageVisibility:")
+    if responds(to: selector) {
+      unsafeBitCast(
+        method(for: selector),
+        to: (@convention(c) (NSMenuItem, Selector, Int) -> Void).self
+      )(self, selector, 1) // .visible
+    } else {
+      assertionFailure("Missing setPreferredImageVisibility:")
+    }
+  #endif
+  }
 }

--- a/LunarBarMac/Sources/Main/AppMainVC+Menu.swift
+++ b/LunarBarMac/Sources/Main/AppMainVC+Menu.swift
@@ -150,6 +150,7 @@ private extension AppMainVC {
       if #available(macOS 26.0, *) {
         // To improve the text alignment
         item.image = .with(symbolName: Icons.menubarRectangle, pointSize: Constants.menuIconSize)
+        item.ensureImageVisibility()
       }
 
       return item
@@ -172,6 +173,7 @@ private extension AppMainVC {
     menu.addItem({
       let item = NSMenuItem(title: Localized.UI.menuTitleCalendarIcon)
       item.image = AppIconFactory.createCalendarIcon(pointSize: Constants.menuIconSize)
+      item.ensureImageVisibility()
       item.setOn(AppPreferences.General.menuBarIcon == .calendar)
 
       item.addAction {
@@ -185,6 +187,7 @@ private extension AppMainVC {
       item: {
         let item = NSMenuItem(title: Localized.UI.menuTitleSystemSymbol)
         item.image = .with(symbolName: Icons.gear, pointSize: Constants.menuIconSize)
+        item.ensureImageVisibility()
         item.setOn(AppPreferences.General.menuBarIcon == .systemSymbol)
         return item
       }(),
@@ -211,6 +214,7 @@ private extension AppMainVC {
       item: {
         let item = NSMenuItem(title: Localized.UI.menuTitleCustomFormat)
         item.image = .with(symbolName: Icons.wandAndSparkles, pointSize: Constants.menuIconSize)
+        item.ensureImageVisibility()
         item.setOn(AppPreferences.General.menuBarIcon == .custom)
         return item
       }(),


### PR DESCRIPTION
These icons are designed to be visible, not part of the macOS Golden Gate design rollback.